### PR TITLE
propcache 0.3.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "propcache" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +7,40 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/propcache-{{ version }}.tar.gz
-  sha256: df81779732feb9d01e5d513fad0122efb3d53bbc75f61b2a4f29a020bc985e70
+  sha256: 40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
+    - cython
     - expandvars
     - setuptools >=47
     - tomli  # [py<311]
-    - cython
     - pip
   run:
     - python
 
 test:
+  source_files:
+    - tests
+    - pytest.ini
   imports:
     - propcache
   commands:
     - pip check
+    - pytest -v
   requires:
     - pip
+    - pytest
+    - pytest-cov >=2.3.1
+    - pytest-xdist
 
 about:
   home: https://github.com/aio-libs/propcache

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cython
+    - cython >=3.0.0
     - expandvars
     - wheel
     - setuptools >=47

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ about:
     - NOTICE
   dev_url: https://github.com/aio-libs/propcache
   doc_url: https://propcache.readthedocs.io
+  description: The module provides a fast implementation of cached properties for Python 3.9+.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - cython
     - expandvars
+    - wheel
     - setuptools >=47
     - tomli  # [py<311]
     - pip


### PR DESCRIPTION
propcache 0.3.1 

**Destination channel:** Default

### Links

- [PKG-7514]
- dev_url:        https://github.com/aio-libs/propcache/tree/v0.3.1
- conda_forge:    https://github.com/conda-forge/propcache-feedstock
- pypi:           https://pypi.org/project/propcache/0.3.1
- pypi inspector: https://inspector.pypi.io/project/propcache/0.3.1

### Explanation of changes:

- new version number


[PKG-7514]: https://anaconda.atlassian.net/browse/PKG-7514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ